### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/containers-tools/cct.png?label=ready&title=Ready)](https://waffle.io/containers-tools/cct)
 # cct
 
 [![Join the chat at https://gitter.im/containers-tools/cct](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/containers-tools/cct?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/containers-tools/cct

This was requested by a real person (user l-d-j) on waffle.io, we're not trying to spam you.
