### PR TITLE
Fix samples/jboss_cli.yaml to use run_cli

### DIFF
--- a/cct/cli/main.py
+++ b/cct/cli/main.py
@@ -95,7 +95,7 @@ class CCT_CLI(object):
             modules = Modules()
             modules.list_module_oper(args.show)
         else:
-            ## env changes overides cmdline ones
+            ## env changes overrides cmdline ones
             ## seems odd but really needed for containers - changes are passed
             ## via docker run -e
             if env_changes:

--- a/samples/jboss_cli.yaml
+++ b/samples/jboss_cli.yaml
@@ -4,4 +4,4 @@
     - jboss.Cli:
       # set jboss home - uses $JBOSS_HOME by default
       - setup:
-      - run: data-source remove --name=ExampleDS
+      - run_cli: data-source remove --name=ExampleDS


### PR DESCRIPTION
The method was renamed during a refactoring
