### PR TITLE
test change processor handling of ints

### DIFF
--- a/cct/module.py
+++ b/cct/module.py
@@ -163,7 +163,7 @@ class Module(object):
     def _process_environment(self, operation):
         if '$' in operation.command:
             operation.command = self._replace_variables(operation.command)
-        for i in xrange(len(operation.args)):
+        for i in range(len(operation.args)):
             if '$' in operation.args[i]:
                 operation.args[i] = self._replace_variables(operation.args[i])
 

--- a/tests/modules/dummy/dummy.py
+++ b/tests/modules/dummy/dummy.py
@@ -1,0 +1,23 @@
+"""
+Copyright (c) 2015 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the MIT license. See the LICENSE file for details.
+"""
+
+import logging
+
+from cct.module import Module
+
+logger = logging.getLogger('cct')
+
+class Dummy(Module):
+    def dump(self, *args):
+        """
+        Dumps arguments to a logfile.
+
+        Args:
+         *args: Will be dumped :).
+        """
+        logger.info("dummy module performed dump with args %s and environment: %s" % (args, self.environment ))

--- a/tests/test_change_processor.py
+++ b/tests/test_change_processor.py
@@ -1,0 +1,43 @@
+"""
+Copyright (c) 2015 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the MIT license. See the LICENSE file for details.
+"""
+
+import os
+import unittest
+import mock
+
+from cct.change_processor import ChangeProcessor
+
+class TestModule(unittest.TestCase):
+    def setUp(self):
+        os.environ['CCT_MODULES_PATH'] = 'tests/modules'
+
+    def test_process_string_values(self):
+        """
+        Make sure that changes that have string values are accepted
+        """
+        config = [{
+            'changes': [{'dummy.Dummy': [{'dump': '493'}]}],
+            'name': 'dummy'
+        }]
+        changerunner = ChangeProcessor(config)
+        changerunner.process()
+
+
+    def test_process_int_values(self):
+        """
+        Make sure that changes that have integer values are accepted
+        """
+        config = [{
+            'changes': [{'dummy.Dummy': [{'dump': 493}]}],
+            'name': 'dummy'
+        }]
+        changerunner = ChangeProcessor(config)
+        changerunner.process()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add a test to demonstrate the problem fixed in #52 

WIP: test still fails, because the base.Dummy module does not exist.
This is because no modules exist in cct source. Tests will therefore
need to: clone a remote module; provide a test module; mock enough
of cct so that it runs. See issue #50.
