### PR TITLE
Added getenv(name) method to cct Module class

### DIFF
--- a/cct/module.py
+++ b/cct/module.py
@@ -118,6 +118,12 @@ class Module(object):
         except:
             pass
 
+    def getenv(self, name):
+        if os.environ.get(name):
+            return os.environ.get(name)
+        if name in self.environment:
+            return self.environment[name]
+        return None
 
     def _process_sources(self, artifacts):
         for artifact in artifacts:

--- a/tests/test_unit_module.py
+++ b/tests/test_unit_module.py
@@ -3,6 +3,7 @@ import os
 import unittest
 
 from cct.module import Modules
+from cct.module import Module
 
 class TestModules(unittest.TestCase):
 
@@ -10,3 +11,24 @@ class TestModules(unittest.TestCase):
         modules = Modules()
         path = os.path.abspath(os.path.dirname(cct.module.__file__)) + "/modules"
         modules.find_modules(path)
+
+    def test_module_getenv_none(self):
+        dummy = Module("dummy", None)
+        self.assertIsNone(dummy.getenv("bar"))
+
+    def test_module_getenv(self):
+        dummy = Module("dummy", None)
+        dummy.environment = { "foo": "foovalue"}
+        self.assertEquals(dummy.getenv("foo"), "foovalue")
+
+    def test_module_getenv_form_host(self):
+        dummy = Module("dummy", None)
+        os.environ['foo'] = "foovalue"
+        self.assertEquals(dummy.getenv("foo"), "foovalue")
+
+    def test_module_getenv_override(self):
+        dummy = Module("dummy", None)
+        dummy.environment = { "foohost": "barvalue"}
+        os.environ['foohost'] = "foovalue"
+        self.assertEquals(dummy.getenv("foohost"), "foovalue")
+


### PR DESCRIPTION
this method enables you to use cct and environment variables via same
API
environment variables from host overrides cct ones, you can use it in a
way:

from cct.module import Module

dummy = Module("dummy", None)
dummy.getenv("foo")
