### PR TITLE
fixed module scanner to ignore test files

### DIFF
--- a/cct/module.py
+++ b/cct/module.py
@@ -232,6 +232,9 @@ class Modules(object):
         """
         logger.debug("discovering modules in %s" %directory)
         for root, _, files in os.walk(directory):
+            candidate_dir = root.replace(directory, "", 1)
+            if candidate_dir.startswith("/tests") or candidate_dir.startswith("/."):
+                continue
             for candidate in files:
                 if os.path.splitext(candidate)[1] == '.py':
                     logger.debug("inspecting %s" %root + "/" + candidate)


### PR DESCRIPTION
now all dirs which startswith /test and /. are ignored and py files
are not loaded from such paths
