### PR TITLE
Adjust module scanner exclusions

### DIFF
--- a/cct/lib/file_utils.py
+++ b/cct/lib/file_utils.py
@@ -42,3 +42,15 @@ def chmod(path, perm, recursive=False):
                 os.chmod(os.path.join(path, root, f), perm)
     else:
         os.chmod(path, perm)
+
+def find(dirname, dirtest, fileaction):
+    """
+    find: recursively traverse a filesystem structure, expanding
+    directories that pass the supplied dirtest, and applying the
+    supplied fileaction to each node.
+    """
+    for child in os.listdir(dirname):
+        fullpath = os.path.join(dirname, child)
+        fileaction(fullpath)
+        if os.path.isdir(fullpath) and dirtest(child):
+            find(fullpath, dirtest, fileaction)

--- a/cct/module.py
+++ b/cct/module.py
@@ -232,7 +232,8 @@ class Modules(object):
         logger.debug("discovering modules in %s" %directory)
         for root, _, files in os.walk(directory):
             candidate_dir = root.replace(directory, "", 1)
-            if candidate_dir.startswith("/tests") or candidate_dir.startswith("/."):
+            if "/tests" in candidate_dir or "/." in candidate_dir:
+                logger.debug("skipping {}, tests or hidden directory".format(candidate_dir))
                 continue
             for candidate in files:
                 if os.path.splitext(candidate)[1] == '.py':


### PR DESCRIPTION
Exclude any path containing /tests or /. to avoid checking for modules
in tests (which can be noisy if e.g. mock is not installed in the run
environment) or .git etc.

Debug log if we skip something since it's a wider check and could be
hard to figure out why a directory was not being looked at.

Fixes #60
