### PR TITLE
changed cct yaml file to contain separate module section

### DIFF
--- a/tests/test_change_processor.py
+++ b/tests/test_change_processor.py
@@ -42,9 +42,9 @@ class TestModule(unittest.TestCase):
     def test_fetch_modules(self):
         config = [{
             'changes': [{'base.Dummy': [{'dump': 493}]},
-                        {'base.Shell': [{'shell': 'echo'},
-                                        {'url': 'https://github.com/containers-tools/base'}]}],
-            'name': 'dummy'
+                        {'base.Shell': [{'shell': 'echo'}]}],
+            'name': 'dummy',
+            'modules': [ {'url': 'https://github.com/containers-tools/base'}]
         }]
         destination = tempfile.mkdtemp()
         changeProcessor = ChangeProcessor(config, destination)


### PR DESCRIPTION
this changed module fetching syntax from:

``` yaml
- changes:
  - base.Shell:
    - url: 'https://github.com/containers-tools/base'
    - shell: ls -l
  - s2i.install:
    - url: 'https://github.com/containers-tools/s2i'
    - install:
  - os-java-misc.install:
    - url: 'https://github.com/containers-tools/os-java'
    - install:
  name: mvn image
```

to

``` yaml
- changes:
  - base.Shell:
    - shell: ls -l
  - s2i.install:
    - {install: null}
  - os-java-misc.install:
    - {install: null}
  name: mvn image
  modules:
    - url: 'https://github.com/containers-tools/s2i'
    - url: 'https://github.com/containers-tools/os-java'
    - url: 'https://github.com/containers-tools/base'
```